### PR TITLE
SOL-3: moving search functionality to back end

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -6,4 +6,16 @@
 
 ## Potential Future Improvements
 
+- Tests seem like a prudent addition to make
+
 - Could implement pagination. Seed the DB with hundreds or thousands of advocates and then what happens to this current implementation? Would be wise to limit requests to something like 20 advocates per page. That could look like a traditional paging UI or an infinite scroll, whichever we prefer. But it would keep our DB requests from faltering as the number of records increases
+
+- Improve the error handling. Maybe return specific information about the failure from the back end and display it in a useful way to the user on the front end. Obviously right now it is pretty trivial. If we cared about observability we could also add some logging around error states
+
+- Maybe allow users to sort the results by a particular field, say `Last Name` for example
+
+- I would like to reference the column name dynamically in my select statement with search term and search term type rather than setting up a cumbersome switch statement to build my drizzle query. I could not find an obvious answer to this in the docs or elsewhere and didn't want to spend too much time diving into this rabbit hole
+
+- When searching by phone number and by years of experience I defaulted to equality. But it would be preferable to check if the search query is contained in the values for those fields. Perhaps this calls for an update to the schema such that those columns are strings. Perhaps a more clever query could be crafted to type cast on the fly
+
+- I've had some trouble integrating with drizzle. I've never used it before today, so I guess it's to be expected. Still, I would want to iron this out if I had more time

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,8 +1,46 @@
+import { NextRequest } from "next/server";
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
+import { eq, ilike } from "drizzle-orm";
 
-export async function GET() {
+async function buildQuery(column: string, value: string) {
+  let whereStatement = ilike(advocates.firstName, `%${value}%`);
+
+  switch(column) {
+    case 'city':
+      whereStatement = ilike(advocates.city, `%${value}%`);
+    case 'lastName':
+      whereStatement = ilike(advocates.lastName, `%${value}%`);
+    case 'degree':
+      whereStatement = ilike(advocates.degree, `%${value}%`);
+    // case 'phoneNumber':
+    //   whereStatement = eq(advocates.phoneNumber, parseInt(value));
+    // case 'specialties':
+    //   whereStatement = ilike(advocates.specialties, `%${value}%`);
+    // case 'yearsOfExperience':
+    //   whereStatement = eq(advocates.yearsOfExperience, parseInt(value));
+    default:
+      break;
+  }
+
+  // getting a strange type error here, `from` returns record[] | never[]
+  // cannot call `where` on type never[]
+  // does not prevent compilation
+  // seems like I am returning no records regardless of search query
+  return await db.select().from(advocates); // .where(whereStatement);
+}
+
+export async function GET(request: NextRequest) {
   try {
+    const searchParams = request.nextUrl.searchParams;
+    const column = searchParams.get('searchTermType');
+    const value = searchParams.get('searchTerm');
+
+    if (column && value) {
+      const data = await buildQuery(column, value);
+      return Response.json({ data });
+    }
+    
     const data = await db.select().from(advocates);
     return Response.json({ data });
   } catch (e) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,21 +10,13 @@ export default function Home() {
   const [searchTerm, setSearchTerm] = useState<string>('');
 
   useEffect(() => {
-    console.log("fetching advocates...");
     fetch("/api/advocates").then((response) => {
       response.json().then((jsonResponse) => {
         setAdvocates(jsonResponse.data);
         setFilteredAdvocates(jsonResponse.data);
       });
-    });
+    }).catch((e) => alert('Oh No Server Error!'));
   }, []);
-
-  const filterSpecialties = (specialties: string[], searchTerm: string): boolean => {
-    const lowerCaseSpecialties = specialties.map((specialty) => specialty.toLowerCase());
-    const joinedSpecialties = lowerCaseSpecialties.join(' ');
-
-    return joinedSpecialties.includes(searchTerm.toLowerCase());
-  };
 
   const onChange = (e: { target: { value: string; }; }) => {
     const currentSearchTerm = e.target.value;
@@ -33,21 +25,11 @@ export default function Home() {
   }
 
   const onSearchClick = () => {
-    const recentlyFilteredAdvocates = advocates.filter((advocate) => {
-      if (searchTermType === 'specialty') {
-        return filterSpecialties(advocate.specialties, searchTerm);
-      }
-
-      if (searchTermType === 'yearsOfExperience') {
-        return advocate.yearsOfExperience.toString().includes(searchTerm);
-      }
-
-      if (typeof advocate[searchTermType] === 'string') {
-        return advocate[searchTermType].toLowerCase().includes(searchTerm.toLowerCase());
-      }      
-    });
-
-    setFilteredAdvocates(recentlyFilteredAdvocates);
+    fetch(`/api/advocates?searchTermType=${searchTermType}&searchTerm=${searchTerm}`).then((response) => {
+      response.json().then((jsonResponse) => {
+        setFilteredAdvocates(jsonResponse.data);
+      });
+    }).catch((e) => alert('Oh No Server Error!'));
   };
 
   const onResetClick = () => {
@@ -71,9 +53,9 @@ export default function Home() {
           <option value="lastName">Last Name</option>
           <option value="city">City</option>
           <option value="degree">Degree</option>
-          <option value="degree">Degree</option>
-          <option value="specialty">Specialty</option>
+          {/* <option value="specialty">Specialty</option>
           <option value="yearsOfExperience">Years of Experience</option>
+          <option value="phoneNumber">Phone Number</option> */}
         </select>
         <input style={{ border: "1px solid black" }} onChange={onChange} value={searchTerm} />
         <button onClick={onSearchClick}>Search</button>


### PR DESCRIPTION
This PR should have been straightforward. I moved the search functionality from the front end to the back end, relying on the ORM to filter based on query params passed along with the request. Yet, I hit a few snags in working with the ORM as described in comments and `DISCUSSION.md`. This is the type of unexpected issue we often have to deal with as software engineers, and I would not normally leave the matter unsettled. But in the interest of the suggested time constraint for this exercise I would like to turn my focus to the UI in my next PR. Maybe this would prove good fodder for a discussion during the next round of the interview process?