### PR TITLE
SOL-5: not using the orm correctly, but at least searching on the back end

### DIFF
--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,47 +1,47 @@
 import { NextRequest } from "next/server";
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
-import { eq, ilike } from "drizzle-orm";
 
-async function buildQuery(column: string, value: string) {
-  let whereStatement = ilike(advocates.firstName, `%${value}%`);
+const filterSpecialties = (specialties: string[], searchTerm: string): boolean => {
+  const lowerCaseSpecialties = specialties.map((specialty) => specialty.toLowerCase());
+  const joinedSpecialties = lowerCaseSpecialties.join(' ');
 
-  switch(column) {
-    case 'city':
-      whereStatement = ilike(advocates.city, `%${value}%`);
-    case 'lastName':
-      whereStatement = ilike(advocates.lastName, `%${value}%`);
-    case 'degree':
-      whereStatement = ilike(advocates.degree, `%${value}%`);
-    // case 'phoneNumber':
-    //   whereStatement = eq(advocates.phoneNumber, parseInt(value));
-    // case 'specialties':
-    //   whereStatement = ilike(advocates.specialties, `%${value}%`);
-    // case 'yearsOfExperience':
-    //   whereStatement = eq(advocates.yearsOfExperience, parseInt(value));
-    default:
-      break;
-  }
+  return joinedSpecialties.includes(searchTerm.toLowerCase());
+};
 
-  // getting a strange type error here, `from` returns record[] | never[]
-  // cannot call `where` on type never[]
-  // does not prevent compilation
-  // seems like I am returning no records regardless of search query
-  return await db.select().from(advocates); // .where(whereStatement);
-}
+const filterResults = (searchTermType: string, searchTerm: string, advocates: any[]) => {
+  const filteredAdvocates = advocates.filter((advocate) => {
+    if (searchTermType === 'specialty') {
+      return filterSpecialties(advocate.specialties, searchTerm);
+    }
+
+    if (searchTermType === 'yearsOfExperience' || searchTermType === 'phoneNumber') {
+      return advocate.yearsOfExperience.toString().includes(searchTerm);
+    }
+
+    if (typeof advocate[searchTermType] === 'string') {
+      return advocate[searchTermType].toLowerCase().includes(searchTerm.toLowerCase());
+    }
+
+  });
+
+  return filteredAdvocates;
+};
 
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;
-    const column = searchParams.get('searchTermType');
-    const value = searchParams.get('searchTerm');
-
-    if (column && value) {
-      const data = await buildQuery(column, value);
-      return Response.json({ data });
-    }
+    const searchTermType = searchParams.get('searchTermType');
+    const searchTerm = searchParams.get('searchTerm');
     
     const data = await db.select().from(advocates);
+
+    if (searchTermType && searchTerm) {
+      const filteredData = filterResults(searchTermType, searchTerm, data);
+
+      return Response.json({ data: filteredData });
+    }
+
     return Response.json({ data });
   } catch (e) {
     throw new Error('Database failure');

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -49,9 +49,9 @@ export default function Home() {
           <option value="lastName">Last Name</option>
           <option value="city">City</option>
           <option value="degree">Degree</option>
-          {/* <option value="specialty">Specialty</option>
+          <option value="specialty">Specialty</option>
           <option value="yearsOfExperience">Years of Experience</option>
-          <option value="phoneNumber">Phone Number</option> */}
+          <option value="phoneNumber">Phone Number</option>
         </select>
         <input style={{ border: "1px solid black" }} onChange={onChange} value={searchTerm} />
         <button className="searchButton" onClick={onSearchClick}>Search</button>


### PR DESCRIPTION
This will be my final PR for this assignment. As I noted in [this PR for SOL-3](https://github.com/FrankCardilloCodes/solace-candidate-assignment/pull/3) I ran into a snag trying to configure drizzle where queries. I did not want to submit an application that had no search functionality and I did not want to stick with the naive approach of handling filtering in the front end that I implemented in [this PR for SOL-2](https://github.com/FrankCardilloCodes/solace-candidate-assignment/pull/2). So this is a compromise. Searching using application code on the back end.